### PR TITLE
Fix Qwen2_5_VLModel generate attribute error

### DIFF
--- a/COMPLETE_FIX_SUMMARY.md
+++ b/COMPLETE_FIX_SUMMARY.md
@@ -1,0 +1,98 @@
+# Complete Qwen2.5 VL Model Fix Summary
+
+## Problem
+The error `'Qwen2_5_VLModel' object has no attribute 'generate'` was occurring because the code was using `AutoModel` instead of `Qwen2VLForConditionalGeneration` to load the Qwen models.
+
+## Root Cause
+- `AutoModel` loads the base model without generation capabilities
+- `Qwen2VLForConditionalGeneration` is the correct class that includes the `generate` method
+- The `generate` method is essential for text generation in vision-language models
+
+## Files Fixed
+
+### 1. Core Signature Extractor Files
+- **signature_extractor.py** - Main signature extractor
+- **signature_extractor_backup.py** - Backup version  
+- **signature_extractor_minimal.py** - Minimal version
+- **advanced_signature_detector.py** - Advanced detector
+
+### 2. Test Files
+- **simple_qwen_test.py** - Simple test script
+- **test_qwen_auto.py** - AutoModel test script
+
+## Changes Made
+
+### Import Statement Updates
+```python
+# Before
+from transformers import AutoModel, AutoProcessor
+
+# After  
+from transformers import Qwen2VLForConditionalGeneration, AutoProcessor
+```
+
+### Model Loading Updates
+```python
+# Before
+self.model = AutoModel.from_pretrained(
+    self.model_name, 
+    torch_dtype=torch.float16 if self.device == "cuda" else torch.float32,
+    device_map="auto" if self.device == "cuda" else None,
+    trust_remote_code=True
+)
+
+# After
+self.model = Qwen2VLForConditionalGeneration.from_pretrained(
+    self.model_name, 
+    torch_dtype=torch.float16 if self.device == "cuda" else torch.float32,
+    device_map="auto" if self.device == "cuda" else None,
+    trust_remote_code=True
+)
+```
+
+### Test Enhancements
+- Added `generate` method availability checks
+- Added actual generation testing in test scripts
+- Enhanced error reporting
+
+## Verification Steps
+
+### 1. Method Availability Check
+```python
+if hasattr(model, 'generate'):
+    print("✅ Model has generate method!")
+else:
+    print("❌ Model does not have generate method!")
+```
+
+### 2. Generation Testing
+```python
+with torch.no_grad():
+    generated_ids = model.generate(
+        **inputs,
+        max_new_tokens=10,
+        do_sample=False
+    )
+```
+
+## Files Created
+- **test_fixed_qwen.py** - Comprehensive test script
+- **FIX_SUMMARY.md** - Initial fix summary
+- **COMPLETE_FIX_SUMMARY.md** - This complete summary
+
+## Expected Results
+After applying these fixes:
+1. ✅ The `generate` method will be available on the model object
+2. ✅ Text generation will work correctly
+3. ✅ Vision-language processing will function as expected
+4. ✅ All existing functionality remains intact
+5. ✅ No more `'Qwen2_5_VLModel' object has no attribute 'generate'` errors
+
+## Testing
+To verify the fix:
+1. Install dependencies: `pip install -r requirements.txt`
+2. Run test script: `python test_fixed_qwen.py`
+3. Test with actual images if needed
+
+## Impact
+This fix resolves the core issue preventing the Qwen models from working properly in the signature detection system. All signature extraction, comparison, and analysis features should now function correctly.

--- a/FIX_SUMMARY.md
+++ b/FIX_SUMMARY.md
@@ -1,0 +1,63 @@
+# Qwen2.5 VL Model Fix Summary
+
+## Problem
+The error `'Qwen2_5_VLModel' object has no attribute 'generate'` was occurring because the code was using `AutoModel` instead of `Qwen2VLForConditionalGeneration` to load the Qwen models.
+
+## Root Cause
+- `AutoModel` loads the base model without generation capabilities
+- `Qwen2VLForConditionalGeneration` is the correct class that includes the `generate` method
+- The `generate` method is essential for text generation in vision-language models
+
+## Files Fixed
+1. **signature_extractor.py** - Main signature extractor
+2. **signature_extractor_backup.py** - Backup version
+3. **signature_extractor_minimal.py** - Minimal version
+4. **advanced_signature_detector.py** - Advanced detector
+
+## Changes Made
+For each file, I updated:
+
+### Import Statement
+```python
+# Before
+from transformers import AutoModel, AutoProcessor
+
+# After
+from transformers import Qwen2VLForConditionalGeneration, AutoProcessor
+```
+
+### Model Loading
+```python
+# Before
+self.model = AutoModel.from_pretrained(
+    self.model_name, 
+    torch_dtype=torch.float16 if self.device == "cuda" else torch.float32,
+    device_map="auto" if self.device == "cuda" else None,
+    trust_remote_code=True
+)
+
+# After
+self.model = Qwen2VLForConditionalGeneration.from_pretrained(
+    self.model_name, 
+    torch_dtype=torch.float16 if self.device == "cuda" else torch.float32,
+    device_map="auto" if self.device == "cuda" else None,
+    trust_remote_code=True
+)
+```
+
+## Verification
+The fix ensures that:
+1. The model object has the `generate` method available
+2. Text generation will work correctly
+3. Vision-language processing will function as expected
+4. All existing functionality remains intact
+
+## Test Script
+Created `test_fixed_qwen.py` to verify the fix works correctly.
+
+## Next Steps
+1. Install dependencies in a virtual environment
+2. Run the test script to verify the fix
+3. Test with actual image processing if needed
+
+The fix addresses the core issue and should resolve the `'Qwen2_5_VLModel' object has no attribute 'generate'` error.

--- a/advanced_signature_detector.py
+++ b/advanced_signature_detector.py
@@ -69,10 +69,10 @@ class AdvancedSignatureDetector:
         """Load the specified Qwen model"""
         print(f"Loading {self.model_name}...")
         try:
-            from transformers import AutoModel, AutoProcessor
+            from transformers import Qwen2VLForConditionalGeneration, AutoProcessor
             
             self.processor = AutoProcessor.from_pretrained(self.model_name, trust_remote_code=True)
-            self.model = AutoModel.from_pretrained(
+            self.model = Qwen2VLForConditionalGeneration.from_pretrained(
                 self.model_name, 
                 torch_dtype=torch.float16 if self.device == "cuda" else torch.float32,
                 device_map="auto" if self.device == "cuda" else None,

--- a/signature_extractor.py
+++ b/signature_extractor.py
@@ -48,10 +48,10 @@ class SignatureExtractor:
         """Load the specified Qwen model"""
         print(f"Loading {self.model_name}...")
         try:
-            from transformers import AutoModel, AutoProcessor
+            from transformers import Qwen2VLForConditionalGeneration, AutoProcessor
             
             self.processor = AutoProcessor.from_pretrained(self.model_name, trust_remote_code=True)
-            self.model = AutoModel.from_pretrained(
+            self.model = Qwen2VLForConditionalGeneration.from_pretrained(
                 self.model_name, 
                 torch_dtype=torch.float16 if self.device == "cuda" else torch.float32,
                 device_map="auto" if self.device == "cuda" else None,
@@ -64,9 +64,9 @@ class SignatureExtractor:
             if "7B" in self.model_name or "32B" in self.model_name or "72B" in self.model_name:
                 print("Trying with smaller 2B model due to memory constraints...")
                 self.model_name = "Qwen/Qwen2-VL-2B-Instruct"
-                from transformers import AutoModel, AutoProcessor
+                from transformers import Qwen2VLForConditionalGeneration, AutoProcessor
                 self.processor = AutoProcessor.from_pretrained(self.model_name, trust_remote_code=True)
-                self.model = AutoModel.from_pretrained(
+                self.model = Qwen2VLForConditionalGeneration.from_pretrained(
                     self.model_name, 
                     torch_dtype=torch.float16 if self.device == "cuda" else torch.float32,
                     device_map="auto" if self.device == "cuda" else None,

--- a/signature_extractor_backup.py
+++ b/signature_extractor_backup.py
@@ -5,7 +5,7 @@ from PIL import Image
 import json
 import sqlite3
 from typing import List, Dict, Tuple, Optional
-from transformers import AutoModel, AutoTokenizer, AutoProcessor
+from transformers import Qwen2VLForConditionalGeneration, AutoTokenizer, AutoProcessor
 import matplotlib.pyplot as plt
 import seaborn as sns
 from sklearn.metrics.pairwise import cosine_similarity
@@ -54,7 +54,7 @@ class SignatureExtractor:
         print(f"Loading {self.model_name}...")
         try:
             self.processor = AutoProcessor.from_pretrained(self.model_name, trust_remote_code=True)
-            self.model = AutoModel.from_pretrained(
+            self.model = Qwen2VLForConditionalGeneration.from_pretrained(
                 self.model_name, 
                 torch_dtype=torch.float16 if self.device == "cuda" else torch.float32,
                 device_map="auto" if self.device == "cuda" else None,
@@ -68,7 +68,7 @@ class SignatureExtractor:
                 print("Trying with smaller 2B model due to memory constraints...")
                 self.model_name = "Qwen/Qwen2-VL-2B-Instruct"
                 self.processor = AutoProcessor.from_pretrained(self.model_name, trust_remote_code=True)
-                self.model = AutoModel.from_pretrained(
+                self.model = Qwen2VLForConditionalGeneration.from_pretrained(
                     self.model_name, 
                     torch_dtype=torch.float16 if self.device == "cuda" else torch.float32,
                     device_map="auto" if self.device == "cuda" else None,

--- a/signature_extractor_minimal.py
+++ b/signature_extractor_minimal.py
@@ -48,10 +48,10 @@ class SignatureExtractor:
         """Load the specified Qwen model"""
         print(f"Loading {self.model_name}...")
         try:
-            from transformers import AutoModel, AutoProcessor
+            from transformers import Qwen2VLForConditionalGeneration, AutoProcessor
             
             self.processor = AutoProcessor.from_pretrained(self.model_name, trust_remote_code=True)
-            self.model = AutoModel.from_pretrained(
+            self.model = Qwen2VLForConditionalGeneration.from_pretrained(
                 self.model_name, 
                 torch_dtype=torch.float16 if self.device == "cuda" else torch.float32,
                 device_map="auto" if self.device == "cuda" else None,
@@ -64,9 +64,9 @@ class SignatureExtractor:
             if "7B" in self.model_name or "32B" in self.model_name or "72B" in self.model_name:
                 print("Trying with smaller 2B model due to memory constraints...")
                 self.model_name = "Qwen/Qwen2-VL-2B-Instruct"
-                from transformers import AutoModel, AutoProcessor
+                from transformers import Qwen2VLForConditionalGeneration, AutoProcessor
                 self.processor = AutoProcessor.from_pretrained(self.model_name, trust_remote_code=True)
-                self.model = AutoModel.from_pretrained(
+                self.model = Qwen2VLForConditionalGeneration.from_pretrained(
                     self.model_name, 
                     torch_dtype=torch.float16 if self.device == "cuda" else torch.float32,
                     device_map="auto" if self.device == "cuda" else None,

--- a/simple_qwen_test.py
+++ b/simple_qwen_test.py
@@ -4,7 +4,7 @@ Simple test to verify Qwen model loading works
 """
 
 import torch
-from transformers import AutoModel, AutoProcessor
+from transformers import Qwen2VLForConditionalGeneration, AutoProcessor
 
 def test_simple_loading():
     """Test simple model loading"""
@@ -18,12 +18,19 @@ def test_simple_loading():
         print("✅ Processor loaded")
         
         print("Loading model...")
-        model = AutoModel.from_pretrained(
+        model = Qwen2VLForConditionalGeneration.from_pretrained(
             model_name,
             torch_dtype=torch.float32,  # Use float32 for CPU
             trust_remote_code=True
         )
         print("✅ Model loaded")
+        
+        # Test that the model has the generate method
+        if hasattr(model, 'generate'):
+            print("✅ Model has generate method!")
+        else:
+            print("❌ Model does not have generate method!")
+            return False
         
         return True
         

--- a/test_qwen_auto.py
+++ b/test_qwen_auto.py
@@ -5,7 +5,7 @@ Test script using AutoModel to load Qwen 2.5-VL
 
 import torch
 import sys
-from transformers import AutoModel, AutoTokenizer, AutoProcessor
+from transformers import Qwen2VLForConditionalGeneration, AutoTokenizer, AutoProcessor
 
 def test_qwen_auto_loading():
     """Test loading Qwen 2.5-VL model using AutoModel"""
@@ -31,7 +31,7 @@ def test_qwen_auto_loading():
         # Load model using AutoModel
         print("Loading model with AutoModel...")
         device = "cuda" if torch.cuda.is_available() else "cpu"
-        model = AutoModel.from_pretrained(
+        model = Qwen2VLForConditionalGeneration.from_pretrained(
             model_name,
             torch_dtype=torch.float16 if device == "cuda" else torch.float32,
             device_map="auto" if device == "cuda" else None,
@@ -65,6 +65,22 @@ def test_qwen_auto_loading():
         )
         print("✅ Text tokenized successfully")
         
+        # Test generation
+        print("Testing generation...")
+        with torch.no_grad():
+            generated_ids = model.generate(
+                **image_inputs,
+                max_new_tokens=10,
+                do_sample=False
+            )
+        
+        generated_ids = [
+            output_ids[len(input_ids):] for input_ids, output_ids in zip(image_inputs.input_ids, generated_ids)
+        ]
+        
+        response = processor.batch_decode(generated_ids, skip_special_tokens=True)[0]
+        print(f"✅ Generation successful: {response}")
+        
         print("\n🎉 Qwen model loading test PASSED!")
         return True
         
@@ -92,7 +108,7 @@ def test_smaller_model():
         # Load model
         print("Loading model...")
         device = "cuda" if torch.cuda.is_available() else "cpu"
-        model = AutoModel.from_pretrained(
+        model = Qwen2VLForConditionalGeneration.from_pretrained(
             model_name,
             torch_dtype=torch.float16 if device == "cuda" else torch.float32,
             device_map="auto" if device == "cuda" else None,


### PR DESCRIPTION
Replace `AutoModel` with `Qwen2VLForConditionalGeneration` for Qwen model loading to resolve the missing `generate` method error.

The `AutoModel` class loads the base model without generation capabilities, leading to the `'Qwen2_5_VLModel' object has no attribute 'generate'` error. Switching to `Qwen2VLForConditionalGeneration` ensures the model is loaded with the necessary generation methods for vision-language tasks.

---
<a href="https://cursor.com/background-agent?bcId=bc-7195c8f6-c395-4aba-9b9e-00907c9cd663">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7195c8f6-c395-4aba-9b9e-00907c9cd663">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

